### PR TITLE
popup: support no archive URL

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -143,7 +143,7 @@ function updatePopup(msg) {
         checkDetailsFold.addEventListener("toggle", updateCommandsWidth);
     }
 
-    if (msg.archiveUrl.indexOf("lore.kernel.org") != -1) {
+    if (msg.archiveUrl && msg.archiveUrl.indexOf("lore.kernel.org") != -1) {
         let lore = document.getElementById("archive-name");
         lore.textContent = "Lore";
     }


### PR DESCRIPTION
On our new patchwork project (MPTCP), we don't have any archive URL.
We still need to understand why.

But because it seems optional, better to  make sure it is defined
before using it to avoid errors: the popup is not fully filled-in.

Signed-off-by: Matthieu Baerts <matthieu.baerts@tessares.net>