### PR TITLE
patches: support @lists.linux.dev ML

### DIFF
--- a/scripts/patches.js
+++ b/scripts/patches.js
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
 
-import { mailingListString } from "./patchwork.js";
+import { mailingListsArray } from "./patchwork.js";
 
 Array.prototype.hasSubstring = function (s) {
     for (let i = 0; i < this.length; i++)
@@ -16,8 +16,17 @@ export function isPatch(message, msgFull) {
     // but I am not sure that tools like l2md
     // (https://git.kernel.org/pub/scm/linux/kernel/git/dborkman/l2md.git/) set
     // them.
-    if (!(message.recipients.hasSubstring(mailingListString) ||
-          message.ccList.hasSubstring(mailingListString)))
+    let allowedList = false;
+
+    for (var mailingListString of mailingListsArray) {
+        if (message.recipients.hasSubstring(mailingListString) ||
+            message.ccList.hasSubstring(mailingListString)) {
+                allowedList = true;
+                break;
+        }
+    }
+
+    if (!allowedList)
         return false;
 
     // message.subject trims the "Re: " prefix, get real subject from msgFull.

--- a/scripts/patchwork.js
+++ b/scripts/patchwork.js
@@ -1,4 +1,4 @@
 /* SPDX-License-Identifier: MIT */
 
 export const APIServer = "https://patchwork.kernel.org/api/1.2";
-export const mailingListString = "@vger.kernel.org";
+export const mailingListsArray = ["@vger.kernel.org", "@lists.linux.dev"];


### PR DESCRIPTION
New created mailing lists are linked to a new domain: lists.linux.dev.

Supporting this ML allow us to use this nice extension with MPTCP
project.

Signed-off-by: Matthieu Baerts <matthieu.baerts@tessares.net>