### PR TITLE
request: set specific User-Agent

### DIFF
--- a/scripts/requests.js
+++ b/scripts/requests.js
@@ -3,7 +3,16 @@
 const AddonName = browser.runtime.getManifest().name;
 
 function sendReq (url) {
-    return fetch(url)
+    let headers = new Headers({
+        "Accept"       : "application/json",
+        "Content-Type" : "application/json",
+        "User-Agent"   : "tb-seams-addon/1.0 (qeole@outlook.com)"
+    });
+
+    return fetch(url, {
+            method  : 'GET',
+            headers : headers
+        })
         .then(resp => resp.json())
         .then(data => {
             return data;


### PR DESCRIPTION
Since the recent Patchwork upgrade on kernel.org, this add-on fails from time to time. I guess it is due to the Anubis protection:

 - when it fails, it is because the [`fetch()`](https://github.com/Qeole/seams/blob/a4a49652aa8673ad601c5773b76ba9dd5d077f27/scripts/requests.js#L6C12-L6C17) instruction doesn't return a JSON.

 - if I open the URL from Thunderbird, and wait to pass the Anubis protection, then the add-on works again.

From what I got from Konstantin on the Users mailing-list, the best solution is to change the user-agent:

> Just give it a real user-agent (...), e.g.:
>
>     linux-firmware-ci/1.x (contact@addr.her)

So I suggest here to use:

    tb-seams-addon/1.0 (qeole's email address)