### PR TITLE
patches: support NNTP messages

### DIFF
--- a/scripts/patches.js
+++ b/scripts/patches.js
@@ -25,6 +25,16 @@ export async function findPatchworkInstance (message, msgFull) {
             patchwork = instance;
             break;
         }
+        // Fallback: Check raw headers directly for NNTP support.
+        // MessageHeader object may not provide recipients/ccList correctly
+        // for NNTP messages, but msgFull.headers contains the raw values.
+        const toHeader = msgFull.headers?.["to"] || [];
+        const ccHeader = msgFull.headers?.["cc"] || [];
+        if (hasSubstring(toHeader, instance.mailingListString) ||
+            hasSubstring(ccHeader, instance.mailingListString)) {
+            patchwork = instance;
+            break;
+        }
     }
     if (!patchwork) {
         return null;


### PR DESCRIPTION
This PR resolves #6.

The existing pattern matcher inspects both `message.recipients` and `message.ccList`, but these fields may be empty for NNTP messages. By checking `msgFull.headers["to"]` and `msgFull.headers["cc"]` instead, we can reliably achieve the intended behavior for NNTP as well. Rather than replacing the normal account mechanism, these header checks are used only as a fallback when the original fields are missing, preserving compatibility.

Tested Environment: Thunderbird 146.0 (aarch64)


**Figure1: Missing Field on NNTP message**

<img width="600" alt="ScreenShot 2025-12-10 at 02 54 13@2x" src="https://github.com/user-attachments/assets/8bc9d528-56d5-4f37-894f-9134a1711be2" />


**Figure2: Raw Header Containing CC and To List on NNTP message**

<img width="600" height="1868" alt="ScreenShot 2025-12-10 at 02 54 44@2x" src="https://github.com/user-attachments/assets/e8f3c8fc-0e71-4c5c-9376-cfc69bd63441" />
